### PR TITLE
Fix diagonal movement speed bug

### DIFF
--- a/Assets/PlayerMovement.cs
+++ b/Assets/PlayerMovement.cs
@@ -15,6 +15,7 @@ public class PlayerMovement : MonoBehaviour
     {
         moveDirection.x = Input.GetAxisRaw("Horizontal");
         moveDirection.y = Input.GetAxisRaw("Vertical");
+        moveDirection = moveDirection.normalized;
     }
 
     void FixedUpdate()


### PR DESCRIPTION
## Summary
- normalize the player's move direction so diagonal movement isn't faster

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846d3f81d3083268eee9c756958be38