### PR TITLE
Add permissions block to automerge workflow

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,18 @@
+name: Auto Merge
+
+on:
+  pull_request_target:
+    types:
+      - labeled
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: peter-evans/enable-pull-request-automerge@v2
+        with:
+          merge-method: squash


### PR DESCRIPTION
## Summary
- create `.github/workflows/automerge.yml`
- configure `permissions` for the default `GITHUB_TOKEN`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846ed2f4560832699b5cb8b6464e266