### PR TITLE
Add enemy AI, difficulty system and improved dungeon generation

### DIFF
--- a/Assets/DifficultyManager.cs
+++ b/Assets/DifficultyManager.cs
@@ -1,0 +1,61 @@
+using UnityEngine;
+
+public class DifficultyManager : MonoBehaviour
+{
+    public static DifficultyManager Instance { get; private set; }
+
+    [Header("Spawn Settings")]
+    public GameObject enemyPrefab;
+    public Transform[] spawnPoints;
+    public float spawnInterval = 5f;
+
+    private float nextSpawnTime;
+    private int enemiesDefeated;
+    private float startTime;
+
+    void Awake()
+    {
+        if (Instance == null)
+            Instance = this;
+        else
+            Destroy(gameObject);
+    }
+
+    void Start()
+    {
+        startTime = Time.time;
+    }
+
+    void Update()
+    {
+        if (Time.time >= nextSpawnTime)
+        {
+            SpawnEnemy();
+            nextSpawnTime = Time.time + spawnInterval / GetDifficultyMultiplier();
+        }
+    }
+
+    void SpawnEnemy()
+    {
+        if (enemyPrefab == null || spawnPoints.Length == 0)
+            return;
+
+        Transform spawn = spawnPoints[Random.Range(0, spawnPoints.Length)];
+        GameObject enemy = Instantiate(enemyPrefab, spawn.position, Quaternion.identity);
+        EnemyHealth eh = enemy.GetComponent<EnemyHealth>();
+        if (eh != null)
+            eh.maxHealth = Mathf.RoundToInt(eh.maxHealth * GetDifficultyMultiplier());
+    }
+
+    public void RegisterKill()
+    {
+        enemiesDefeated++;
+    }
+
+    float GetDifficultyMultiplier()
+    {
+        float timeFactor = (Time.time - startTime) / 60f;
+        float killFactor = enemiesDefeated * 0.1f;
+        return 1f + timeFactor + killFactor;
+    }
+}

--- a/Assets/DifficultyManager.cs.meta
+++ b/Assets/DifficultyManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 43d07cb783a248e0921b22009cdf6e30

--- a/Assets/DungeonGenerator.cs
+++ b/Assets/DungeonGenerator.cs
@@ -1,0 +1,69 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public class DungeonGenerator : MonoBehaviour
+{
+    public GameObject floorPrefab;
+    public GameObject wallPrefab;
+    public int steps = 50;
+
+    private HashSet<Vector2Int> floorPositions = new HashSet<Vector2Int>();
+
+    void Start()
+    {
+        GenerateDungeon();
+    }
+
+    void GenerateDungeon()
+    {
+        Vector2Int currentPosition = Vector2Int.zero;
+        floorPositions.Add(currentPosition);
+
+        for (int i = 0; i < steps; i++)
+        {
+            currentPosition += GetRandomDirection();
+            floorPositions.Add(currentPosition);
+        }
+
+        foreach (var pos in floorPositions)
+        {
+            Instantiate(floorPrefab, new Vector3(pos.x, pos.y, 1f), Quaternion.identity, transform);
+        }
+
+        HashSet<Vector2Int> wallPositions = new HashSet<Vector2Int>();
+        foreach (var pos in floorPositions)
+        {
+            foreach (Vector2Int dir in Directions())
+            {
+                Vector2Int wallPos = pos + dir;
+                if (!floorPositions.Contains(wallPos))
+                    wallPositions.Add(wallPos);
+            }
+        }
+
+        foreach (var pos in wallPositions)
+        {
+            Instantiate(wallPrefab, new Vector3(pos.x, pos.y, 1f), Quaternion.identity, transform);
+        }
+    }
+
+    Vector2Int GetRandomDirection()
+    {
+        int index = Random.Range(0, 4);
+        switch (index)
+        {
+            case 0: return Vector2Int.up;
+            case 1: return Vector2Int.down;
+            case 2: return Vector2Int.left;
+            default: return Vector2Int.right;
+        }
+    }
+
+    IEnumerable<Vector2Int> Directions()
+    {
+        yield return Vector2Int.up;
+        yield return Vector2Int.down;
+        yield return Vector2Int.left;
+        yield return Vector2Int.right;
+    }
+}

--- a/Assets/DungeonGenerator.cs.meta
+++ b/Assets/DungeonGenerator.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6859f71b451d437d82d4d666ee57f52a

--- a/Assets/EnemyAI.cs
+++ b/Assets/EnemyAI.cs
@@ -1,0 +1,91 @@
+using UnityEngine;
+
+[RequireComponent(typeof(Rigidbody2D))]
+public class EnemyAI : MonoBehaviour
+{
+    public float chaseRange = 5f;
+    public float attackRange = 1f;
+    public float moveSpeed = 2f;
+    public float attackCooldown = 1f;
+
+    private Transform player;
+    private Rigidbody2D rb;
+    private float lastAttackTime;
+
+    private enum State { Idle, Chase, Attack }
+    private State currentState = State.Idle;
+
+    void Start()
+    {
+        player = GameObject.FindGameObjectWithTag("Player")?.transform;
+        rb = GetComponent<Rigidbody2D>();
+    }
+
+    void Update()
+    {
+        if (player == null)
+            return;
+
+        float distance = Vector2.Distance(player.position, transform.position);
+        switch (currentState)
+        {
+            case State.Idle:
+                if (distance <= chaseRange)
+                    currentState = State.Chase;
+                break;
+            case State.Chase:
+                if (distance <= attackRange)
+                    currentState = State.Attack;
+                else if (distance > chaseRange)
+                    currentState = State.Idle;
+                break;
+            case State.Attack:
+                if (distance > attackRange)
+                    currentState = State.Chase;
+                break;
+        }
+    }
+
+    void FixedUpdate()
+    {
+        if (player == null)
+            return;
+
+        switch (currentState)
+        {
+            case State.Chase:
+                Vector2 dir = ((Vector2)player.position - rb.position).normalized;
+                rb.MovePosition(rb.position + dir * moveSpeed * Time.fixedDeltaTime);
+                break;
+            case State.Attack:
+                TryAttack();
+                break;
+        }
+    }
+
+    void TryAttack()
+    {
+        if (Time.time < lastAttackTime + attackCooldown)
+            return;
+
+        lastAttackTime = Time.time;
+        Collider2D[] hits = Physics2D.OverlapCircleAll(transform.position, attackRange);
+        foreach (var hit in hits)
+        {
+            if (hit.CompareTag("Player"))
+            {
+                PlayerHealth ph = hit.GetComponent<PlayerHealth>();
+                if (ph != null)
+                    ph.TakeDamage(1);
+            }
+        }
+    }
+
+    void OnDrawGizmosSelected()
+    {
+        Gizmos.color = Color.yellow;
+        Gizmos.DrawWireSphere(transform.position, chaseRange);
+        Gizmos.color = Color.red;
+        Gizmos.DrawWireSphere(transform.position, attackRange);
+    }
+}

--- a/Assets/EnemyAI.cs.meta
+++ b/Assets/EnemyAI.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e74b5e6ecae44530aa30b03928efb4d5

--- a/Assets/EnemyHealth.cs
+++ b/Assets/EnemyHealth.cs
@@ -18,6 +18,8 @@ public class EnemyHealth : MonoBehaviour
         if (currentHealth <= 0)
         {
             Destroy(gameObject);
+            if (DifficultyManager.Instance != null)
+                DifficultyManager.Instance.RegisterKill();
         }
     }
 }

--- a/Assets/PlayerAttack.cs
+++ b/Assets/PlayerAttack.cs
@@ -33,7 +33,10 @@ public class PlayerAttack : MonoBehaviour
         {
             var enemyHealth = hit.GetComponent<EnemyHealth>();
             if (enemyHealth != null)
+            {
                 enemyHealth.TakeDamage(1);
+                Debug.Log($"Damaged {hit.name}");
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- add hashset-based procedural DungeonGenerator
- implement EnemyAI state machine
- create DifficultyManager for adaptive spawning and scaling
- notify DifficultyManager on enemy death
- log hits when PlayerAttack damages enemies

## Testing
- `mcs --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846f0c1e1708326baf77389dd2a90fe