### PR TITLE
Fix automerge workflow

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -13,6 +13,12 @@ jobs:
   automerge:
     runs-on: ubuntu-latest
     steps:
-      - uses: peter-evans/enable-pull-request-automerge@v2
+      - name: Fetch pull request number
+        id: fetch_pr
+        run: echo "PR_NUMBER=${{ github.event.pull_request.number }}" >> $GITHUB_ENV
+      - name: Enable auto-merge
+        if: env.PR_NUMBER != ''
+        uses: peter-evans/enable-pull-request-automerge@v2
         with:
           merge-method: squash
+


### PR DESCRIPTION
## Summary
- ensure the automerge job grabs the PR id
- only run the automerge action when a PR number is available

## Testing
- `pre-commit run --files .github/workflows/automerge.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846f212ee748326bb8a79696626e2bf