### PR TITLE
Add adaptive difficulty and patrol AI

### DIFF
--- a/Assets/DifficultyManager.cs
+++ b/Assets/DifficultyManager.cs
@@ -45,6 +45,9 @@ public class DifficultyManager : MonoBehaviour
         EnemyHealth eh = enemy.GetComponent<EnemyHealth>();
         if (eh != null)
             eh.maxHealth = Mathf.RoundToInt(eh.maxHealth * GetDifficultyMultiplier());
+        EnemyAI ai = enemy.GetComponent<EnemyAI>();
+        if (ai != null)
+            ai.damage = Mathf.RoundToInt(ai.damage * GetDifficultyMultiplier());
     }
 
     public void RegisterKill()

--- a/Assets/DungeonGenerator.cs
+++ b/Assets/DungeonGenerator.cs
@@ -6,11 +6,18 @@ public class DungeonGenerator : MonoBehaviour
     public GameObject floorPrefab;
     public GameObject wallPrefab;
     public int steps = 50;
+    public bool randomSeed = true;
+    public int seed = 0;
 
     private HashSet<Vector2Int> floorPositions = new HashSet<Vector2Int>();
 
     void Start()
     {
+        if (randomSeed)
+            Random.InitState(System.DateTime.Now.GetHashCode());
+        else
+            Random.InitState(seed);
+        ClearChildren();
         GenerateDungeon();
     }
 
@@ -45,6 +52,15 @@ public class DungeonGenerator : MonoBehaviour
         {
             Instantiate(wallPrefab, new Vector3(pos.x, pos.y, 1f), Quaternion.identity, transform);
         }
+    }
+
+    void ClearChildren()
+    {
+        for (int i = transform.childCount - 1; i >= 0; i--)
+        {
+            Destroy(transform.GetChild(i).gameObject);
+        }
+        floorPositions.Clear();
     }
 
     Vector2Int GetRandomDirection()

--- a/Assets/EnemyAI.cs
+++ b/Assets/EnemyAI.cs
@@ -7,18 +7,23 @@ public class EnemyAI : MonoBehaviour
     public float attackRange = 1f;
     public float moveSpeed = 2f;
     public float attackCooldown = 1f;
+    public int damage = 1;
+    public float patrolChangeInterval = 2f;
 
     private Transform player;
     private Rigidbody2D rb;
     private float lastAttackTime;
 
-    private enum State { Idle, Chase, Attack }
+    private enum State { Idle, Patrol, Chase, Attack }
     private State currentState = State.Idle;
+    private Vector2 patrolDirection;
+    private float nextPatrolChange;
 
     void Start()
     {
         player = GameObject.FindGameObjectWithTag("Player")?.transform;
         rb = GetComponent<Rigidbody2D>();
+        ChooseNewPatrolDirection();
     }
 
     void Update()
@@ -30,14 +35,19 @@ public class EnemyAI : MonoBehaviour
         switch (currentState)
         {
             case State.Idle:
+                currentState = State.Patrol;
+                break;
+            case State.Patrol:
                 if (distance <= chaseRange)
                     currentState = State.Chase;
+                if (Time.time >= nextPatrolChange)
+                    ChooseNewPatrolDirection();
                 break;
             case State.Chase:
                 if (distance <= attackRange)
                     currentState = State.Attack;
                 else if (distance > chaseRange)
-                    currentState = State.Idle;
+                    currentState = State.Patrol;
                 break;
             case State.Attack:
                 if (distance > attackRange)
@@ -53,6 +63,9 @@ public class EnemyAI : MonoBehaviour
 
         switch (currentState)
         {
+            case State.Patrol:
+                rb.MovePosition(rb.position + patrolDirection * moveSpeed * Time.fixedDeltaTime);
+                break;
             case State.Chase:
                 Vector2 dir = ((Vector2)player.position - rb.position).normalized;
                 rb.MovePosition(rb.position + dir * moveSpeed * Time.fixedDeltaTime);
@@ -76,9 +89,16 @@ public class EnemyAI : MonoBehaviour
             {
                 PlayerHealth ph = hit.GetComponent<PlayerHealth>();
                 if (ph != null)
-                    ph.TakeDamage(1);
+                    ph.TakeDamage(damage);
             }
         }
+    }
+
+    void ChooseNewPatrolDirection()
+    {
+        float angle = Random.Range(0f, Mathf.PI * 2f);
+        patrolDirection = new Vector2(Mathf.Cos(angle), Mathf.Sin(angle));
+        nextPatrolChange = Time.time + patrolChangeInterval;
     }
 
     void OnDrawGizmosSelected()

--- a/Assets/EnemyHealth.cs
+++ b/Assets/EnemyHealth.cs
@@ -4,6 +4,7 @@ public class EnemyHealth : MonoBehaviour
 {
     public int maxHealth = 3;
     private int currentHealth;
+    public FloatingDamageText damageTextPrefab;
 
     void Start()
     {
@@ -14,6 +15,11 @@ public class EnemyHealth : MonoBehaviour
     {
         currentHealth -= amount;
         Debug.Log("Enemy Health: " + currentHealth);
+        if (damageTextPrefab != null)
+        {
+            var text = Instantiate(damageTextPrefab, transform.position, Quaternion.identity);
+            text.Setup(amount);
+        }
 
         if (currentHealth <= 0)
         {

--- a/Assets/PlayerHealth.cs
+++ b/Assets/PlayerHealth.cs
@@ -4,6 +4,7 @@ public class PlayerHealth : MonoBehaviour
 {
     public int maxHealth = 5;
     private int currentHealth;
+    public FloatingDamageText damageTextPrefab;
 
     void Start()
     {
@@ -14,6 +15,11 @@ public class PlayerHealth : MonoBehaviour
     {
         currentHealth -= amount;
         Debug.Log("Player Health: " + currentHealth);
+        if (damageTextPrefab != null)
+        {
+            var text = Instantiate(damageTextPrefab, transform.position, Quaternion.identity);
+            text.Setup(amount);
+        }
 
         if (currentHealth <= 0)
         {

--- a/Assets/Scripts/FloatingDamageText.cs
+++ b/Assets/Scripts/FloatingDamageText.cs
@@ -1,0 +1,26 @@
+using UnityEngine;
+using TMPro;
+
+public class FloatingDamageText : MonoBehaviour
+{
+    public float lifetime = 1f;
+    public Vector3 moveVector = new Vector3(0, 1f, 0);
+    private TextMeshPro text;
+
+    void Awake()
+    {
+        text = GetComponent<TextMeshPro>();
+    }
+
+    public void Setup(int damage)
+    {
+        if (text != null)
+            text.text = damage.ToString();
+        Destroy(gameObject, lifetime);
+    }
+
+    void Update()
+    {
+        transform.position += moveVector * Time.deltaTime;
+    }
+}

--- a/Assets/Scripts/FloatingDamageText.cs.meta
+++ b/Assets/Scripts/FloatingDamageText.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f36d8eaa7dcb4c07b642b748f5f991a3


### PR DESCRIPTION
## Summary
- upgrade DungeonGenerator to support random seeds and clearing previous tiles
- expand EnemyAI with patrol state and damage property
- scale enemy damage in DifficultyManager
- show floating damage text for player and enemies

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6847407331a48326a4034da09e23de1b