### PR TITLE
Regenerate room when enemy dies

### DIFF
--- a/Assets/EnemyHealth.cs
+++ b/Assets/EnemyHealth.cs
@@ -26,6 +26,9 @@ public class EnemyHealth : MonoBehaviour
             Destroy(gameObject);
             if (DifficultyManager.Instance != null)
                 DifficultyManager.Instance.RegisterKill();
+            RoomGenerator rg = FindObjectOfType<RoomGenerator>();
+            if (rg != null)
+                rg.RegenerateRoom();
         }
     }
 }

--- a/Assets/RoomGenerator.cs
+++ b/Assets/RoomGenerator.cs
@@ -9,6 +9,12 @@ public class RoomGenerator : MonoBehaviour
 
     void Start()
     {
+        RegenerateRoom();
+    }
+
+    public void RegenerateRoom()
+    {
+        ClearChildren();
         GenerateRoom();
     }
 
@@ -29,6 +35,14 @@ public class RoomGenerator : MonoBehaviour
         {
             Instantiate(wallPrefab, new Vector3(-1, y, 1f), Quaternion.identity, transform);
             Instantiate(wallPrefab, new Vector3(width, y, 1f), Quaternion.identity, transform);
+        }
+    }
+
+    void ClearChildren()
+    {
+        for (int i = transform.childCount - 1; i >= 0; i--)
+        {
+            Destroy(transform.GetChild(i).gameObject);
         }
     }
 }


### PR DESCRIPTION
## Summary
- regenerate room when an enemy dies so floors/walls don't stack
- add public method in `RoomGenerator` to clear and create the room
- call new method in `EnemyHealth` when health reaches zero

## Testing
- `apt-get update`
- `apt-get install -y mono-devel`
- `mcs Assets/EnemyHealth.cs Assets/RoomGenerator.cs -r:UnityEngine.dll` *(fails: `UnityEngine.dll` not found)*


------
https://chatgpt.com/codex/tasks/task_e_68474295bc648326b1ca20b2d17b8bd2