### PR TITLE
Fix automerge PR number

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -20,5 +20,6 @@ jobs:
         if: env.PR_NUMBER != ''
         uses: peter-evans/enable-pull-request-automerge@v2
         with:
+          pull-request-number: ${{ env.PR_NUMBER }}
           merge-method: squash
 


### PR DESCRIPTION
## Summary
- ensure the enable-pull-request-automerge action receives the PR number

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68474c37c2b48326b0fe42244bf673c4