### PR TITLE
Fix Unity warnings

### DIFF
--- a/Assets/EnemyHealth.cs
+++ b/Assets/EnemyHealth.cs
@@ -26,7 +26,7 @@ public class EnemyHealth : MonoBehaviour
             Destroy(gameObject);
             if (DifficultyManager.Instance != null)
                 DifficultyManager.Instance.RegisterKill();
-            RoomGenerator rg = FindObjectOfType<RoomGenerator>();
+            RoomGenerator rg = FindAnyObjectByType<RoomGenerator>();
             if (rg != null)
                 rg.RegenerateRoom();
         }

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -15,33 +15,29 @@ TagManager:
   - UI
   - Enemy
   -
-  - 
-  - 
-  - 
-  - 
-  - 
-  - 
-  - 
-  - 
-  - 
-  - 
-  - 
-  - 
-  - 
-  - 
-  - 
-  - 
-  - 
-  - 
-  - 
-  - 
-  - 
-  - 
-  - 
-  - 
+  -
+  -
+  -
+  -
+  -
+  -
+  -
+  -
+  -
+  -
+  -
+  -
+  -
+  -
+  -
+  -
+  -
+  -
+  -
+  -
   m_SortingLayers:
-    - name: Default
-      uniqueID: 0
-      locked: 0
+  - name: Default
+    uniqueID: 0
+    locked: 0
   m_RenderingLayers:
-    - Default
+  - Default


### PR DESCRIPTION
## Summary
- fix usage of `FindObjectOfType` in `EnemyHealth`
- clean up indentation in `TagManager.asset` to resolve YAML parse errors

## Testing
- `python3 - <<'PY'
import yaml
class UnityLoader(yaml.SafeLoader):
    pass
UnityLoader.add_constructor('tag:unity3d.com,2011:78', lambda loader,node: loader.construct_mapping(node))
try:
    yaml.load(open('ProjectSettings/TagManager.asset'), Loader=UnityLoader)
    print('ok')
except Exception as e:
    print('error:', e)
PY`

------
https://chatgpt.com/codex/tasks/task_e_6847529483608326a01199159a7cd675