### PR TITLE
Fix TagManager asset YAML formatting

### DIFF
--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -4,40 +4,44 @@
 TagManager:
   serializedVersion: 3
   tags:
-  - Wall
-  - Enemy
+    - Wall
+    - Enemy
   layers:
-  - Default
-  - TransparentFX
-  - Ignore Raycast
-  -
-  - Water
-  - UI
-  - Enemy
-  -
-  -
-  -
-  -
-  -
-  -
-  -
-  -
-  -
-  -
-  -
-  -
-  -
-  -
-  -
-  -
-  -
-  -
-  -
-  -
-  -
+    - Default
+    - TransparentFX
+    - Ignore Raycast
+    -
+    - Water
+    - UI
+    - Enemy
+    -
+    -
+    -
+    -
+    -
+    -
+    -
+    -
+    -
+    -
+    -
+    -
+    -
+    -
+    -
+    -
+    -
+    -
+    -
+    -
+    -
+    -
+    -
+    -
+    -
   m_SortingLayers:
-  - name: Default
-    uniqueID: 0
-    locked: 0
+    - name: Default
+      uniqueID: 0
+      locked: 0
   m_RenderingLayers:
-  - Default
+    - Default


### PR DESCRIPTION
## Summary
- fix indentation in `TagManager.asset`
- ensure 32 layer entries to avoid YAML parse errors

## Testing
- `yamllint ProjectSettings/TagManager.asset`

------
https://chatgpt.com/codex/tasks/task_e_684766df898c8326a20c57e2694a5568