### PR TITLE
Add basic XP system and upgrades

### DIFF
--- a/Assets/EnemyHealth.cs
+++ b/Assets/EnemyHealth.cs
@@ -4,6 +4,7 @@ public class EnemyHealth : MonoBehaviour
 {
     public int maxHealth = 3;
     private int currentHealth;
+    public int experienceReward = 1;
     public FloatingDamageText damageTextPrefab;
 
     void Start()
@@ -23,6 +24,10 @@ public class EnemyHealth : MonoBehaviour
 
         if (currentHealth <= 0)
         {
+            PlayerExperience pe = FindAnyObjectByType<PlayerExperience>();
+            if (pe != null)
+                pe.AddExperience(experienceReward);
+
             Destroy(gameObject);
             if (DifficultyManager.Instance != null)
                 DifficultyManager.Instance.RegisterKill();

--- a/Assets/PlayerAttack.cs
+++ b/Assets/PlayerAttack.cs
@@ -8,6 +8,7 @@ public class PlayerAttack : MonoBehaviour
     private float lastAttackTime = -999f;
     private Vector3 originalScale;
     public float scaleMultiplier = 1.2f;
+    public int damage = 1;
 
     void Start()
     {
@@ -34,7 +35,7 @@ public class PlayerAttack : MonoBehaviour
             var enemyHealth = hit.GetComponent<EnemyHealth>();
             if (enemyHealth != null)
             {
-                enemyHealth.TakeDamage(1);
+                enemyHealth.TakeDamage(damage);
                 Debug.Log($"Damaged {hit.name}");
             }
         }

--- a/Assets/PlayerExperience.cs
+++ b/Assets/PlayerExperience.cs
@@ -1,0 +1,104 @@
+using UnityEngine;
+using System;
+using System.Collections.Generic;
+
+public class PlayerExperience : MonoBehaviour
+{
+    public int level = 1;
+    public int experience;
+    public int experienceToNextLevel = 5;
+    public float xpMultiplier = 1f;
+
+    private bool choosingUpgrade;
+    private List<Upgrade> upgrades;
+    private List<Upgrade> currentChoices;
+
+    private PlayerAttack attack;
+    private PlayerMovement movement;
+
+    void Start()
+    {
+        attack = GetComponent<PlayerAttack>();
+        movement = GetComponent<PlayerMovement>();
+        SetupUpgrades();
+    }
+
+    void SetupUpgrades()
+    {
+        upgrades = new List<Upgrade>
+        {
+            new Upgrade {
+                description = "Increase Damage",
+                action = () => { if (attack != null) attack.damage += 1; }
+            },
+            new Upgrade {
+                description = "Increase XP Gain",
+                action = () => { xpMultiplier += 0.5f; }
+            },
+            new Upgrade {
+                description = "Increase Move Speed",
+                action = () => { if (movement != null) movement.moveSpeed += 1f; }
+            }
+        };
+    }
+
+    public void AddExperience(int amount)
+    {
+        if (choosingUpgrade)
+            return;
+        experience += Mathf.RoundToInt(amount * xpMultiplier);
+        if (experience >= experienceToNextLevel)
+        {
+            experience -= experienceToNextLevel;
+            level++;
+            experienceToNextLevel = Mathf.RoundToInt(experienceToNextLevel * 1.5f);
+            ShowUpgradeOptions();
+        }
+    }
+
+    void ShowUpgradeOptions()
+    {
+        choosingUpgrade = true;
+        Time.timeScale = 0f;
+        currentChoices = new List<Upgrade>();
+        List<int> pool = new List<int>();
+        for (int i = 0; i < upgrades.Count; i++)
+            pool.Add(i);
+        for (int i = 0; i < 3 && pool.Count > 0; i++)
+        {
+            int idx = UnityEngine.Random.Range(0, pool.Count);
+            currentChoices.Add(upgrades[pool[idx]]);
+            pool.RemoveAt(idx);
+        }
+    }
+
+    void ApplyUpgrade(int index)
+    {
+        if (currentChoices == null || index >= currentChoices.Count)
+            return;
+        currentChoices[index].action.Invoke();
+        choosingUpgrade = false;
+        Time.timeScale = 1f;
+    }
+
+    void OnGUI()
+    {
+        if (!choosingUpgrade)
+            return;
+        int width = 200;
+        int height = 40;
+        for (int i = 0; i < currentChoices.Count; i++)
+        {
+            if (GUI.Button(new Rect(10, 10 + i * (height + 10), width, height), currentChoices[i].description))
+            {
+                ApplyUpgrade(i);
+            }
+        }
+    }
+
+    class Upgrade
+    {
+        public string description;
+        public Action action;
+    }
+}

--- a/Assets/PlayerExperience.cs.meta
+++ b/Assets/PlayerExperience.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: fae9c61c11bd406393e6c9b80c8a15c4

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -183,6 +183,7 @@ GameObject:
   - component: {fileID: 126443108}
   - component: {fileID: 126443109}
   - component: {fileID: 126443110}
+  - component: {fileID: 126443111}
   m_Layer: 0
   m_Name: Player
   m_TagString: Player
@@ -389,6 +390,22 @@ Animator:
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorStateOnDisable: 0
   m_WriteDefaultValuesOnDisable: 0
+--- !u!114 &126443111
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 126443102}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fae9c61c11bd406393e6c9b80c8a15c4, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  level: 1
+  experience: 0
+  experienceToNextLevel: 5
+  xpMultiplier: 1
 --- !u!1 &519420028
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
## Summary
- implement `PlayerExperience` to track XP and show upgrade options
- allow player attacks to have configurable damage
- grant XP on enemy death
- reference `PlayerExperience` in `SampleScene`

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6847f11be5808326a36ba2553399241b