### PR TITLE
Add level up manager and upgrade system

### DIFF
--- a/Assets/LevelUpManager.cs
+++ b/Assets/LevelUpManager.cs
@@ -1,0 +1,90 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class LevelUpManager : MonoBehaviour
+{
+    public static LevelUpManager Instance { get; private set; }
+
+    public GameObject optionPanel;
+    public Button optionButtonPrefab;
+    public PlayerAttack playerAttack;
+    public PlayerMovement playerMovement;
+    public PlayerExperience playerExperience;
+
+    private void Awake()
+    {
+        if (Instance == null)
+            Instance = this;
+        else
+            Destroy(gameObject);
+
+        if (optionPanel == null)
+            CreateDefaultUI();
+
+        if (optionPanel != null)
+            optionPanel.SetActive(false);
+    }
+
+    void CreateDefaultUI()
+    {
+        var canvasGO = new GameObject("LevelUpCanvas");
+        var canvas = canvasGO.AddComponent<Canvas>();
+        canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+        canvasGO.AddComponent<CanvasScaler>();
+        canvasGO.AddComponent<GraphicRaycaster>();
+
+        optionPanel = new GameObject("OptionsPanel");
+        optionPanel.transform.SetParent(canvasGO.transform);
+        var rt = optionPanel.AddComponent<RectTransform>();
+        rt.anchorMin = new Vector2(0.5f, 0.5f);
+        rt.anchorMax = new Vector2(0.5f, 0.5f);
+        rt.sizeDelta = new Vector2(200, 200);
+        optionPanel.AddComponent<Image>();
+
+        optionButtonPrefab = new GameObject("OptionButton").AddComponent<Button>();
+        var txt = new GameObject("Text").AddComponent<Text>();
+        txt.transform.SetParent(optionButtonPrefab.transform);
+        txt.alignment = TextAnchor.MiddleCenter;
+        txt.font = Resources.GetBuiltinResource<Font>("Arial.ttf");
+        optionButtonPrefab.GetComponent<RectTransform>().sizeDelta = new Vector2(180, 40);
+        optionButtonPrefab.gameObject.SetActive(false);
+    }
+
+    public void ShowLevelUpOptions()
+    {
+        if (optionPanel == null || optionButtonPrefab == null)
+            return;
+
+        optionPanel.SetActive(true);
+
+        foreach (Transform child in optionPanel.transform)
+            Destroy(child.gameObject);
+
+        var upgrades = new List<(string label, System.Action apply)>
+        {
+            ("Increase Damage", () => { if (playerAttack != null) playerAttack.damage++; }),
+            ("Increase XP Gain", () => { if (playerExperience != null) playerExperience.xpMultiplier++; }),
+            ("Increase Move Speed", () => { if (playerMovement != null) playerMovement.moveSpeed += 1f; })
+        };
+
+        var chosen = new List<(string,System.Action)>();
+        while (chosen.Count < 3 && upgrades.Count > 0)
+        {
+            int index = Random.Range(0, upgrades.Count);
+            chosen.Add(upgrades[index]);
+            upgrades.RemoveAt(index);
+        }
+
+        foreach (var up in chosen)
+        {
+            var btn = Instantiate(optionButtonPrefab, optionPanel.transform);
+            var text = btn.GetComponentInChildren<Text>();
+            if (text != null) text.text = up.label;
+            btn.onClick.AddListener(() => {
+                up.apply();
+                optionPanel.SetActive(false);
+            });
+        }
+    }
+}

--- a/Assets/LevelUpManager.cs.meta
+++ b/Assets/LevelUpManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2dd5d70829414369ae59b64c327bcc89

--- a/Assets/PlayerExperience.cs
+++ b/Assets/PlayerExperience.cs
@@ -2,11 +2,24 @@ using UnityEngine;
 
 public class PlayerExperience : MonoBehaviour
 {
-    public int experience;
+    public int level = 1;
+    public int experience = 0;
+    public int experienceToNextLevel = 5;
+    public int xpMultiplier = 1;
 
     public void AddExperience(int amount)
     {
-        experience += amount;
+        experience += amount * xpMultiplier;
         Debug.Log("Player XP: " + experience);
+
+        if (experience >= experienceToNextLevel)
+        {
+            if (LevelUpManager.Instance != null)
+                LevelUpManager.Instance.ShowLevelUpOptions();
+
+            experience -= experienceToNextLevel;
+            level++;
+            experienceToNextLevel += 5;
+        }
     }
 }

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -399,7 +399,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 126443102}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fae9c61c11bd406393e6c9b80c8a15c4, type: 3}
+  m_Script: {fileID: 11500000, guid: e82fda5bbd134a7f980f5ab96cffbb80, type: 3}
   m_Name:
   m_EditorClassIdentifier:
   level: 1
@@ -823,6 +823,55 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   maxHealth: 3
+--- !u!1 &135000000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 135000001}
+  - component: {fileID: 135000002}
+  m_Layer: 0
+  m_Name: LevelUpManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &135000001
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 135000000}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &135000002
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 135000000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2dd5d70829414369ae59b64c327bcc89, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  optionPanel: {fileID: 0}
+  optionButtonPrefab: {fileID: 0}
+  playerAttack: {fileID: 126443109}
+  playerMovement: {fileID: 126443103}
+  playerExperience: {fileID: 126443111}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
@@ -832,3 +881,4 @@ SceneRoots:
   - {fileID: 126443107}
   - {fileID: 1096257158}
   - {fileID: 84016986}
+  - {fileID: 135000001}


### PR DESCRIPTION
## Summary
- manage XP thresholds and upgrades via `LevelUpManager`
- notify `LevelUpManager` from `PlayerExperience`
- create runtime UI for upgrade options
- reference the new manager in `SampleScene`

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_68485177ca7883269e80ebf919bd0255