### PR TITLE
Change enemy spawn to use camera bounds

### DIFF
--- a/Assets/DifficultyManager.cs
+++ b/Assets/DifficultyManager.cs
@@ -6,7 +6,6 @@ public class DifficultyManager : MonoBehaviour
 
     [Header("Spawn Settings")]
     public GameObject enemyPrefab;
-    public Transform[] spawnPoints;
     public float spawnInterval = 5f;
 
     private float nextSpawnTime;
@@ -37,17 +36,55 @@ public class DifficultyManager : MonoBehaviour
 
     void SpawnEnemy()
     {
-        if (enemyPrefab == null || spawnPoints.Length == 0)
+        if (enemyPrefab == null)
             return;
 
-        Transform spawn = spawnPoints[Random.Range(0, spawnPoints.Length)];
-        GameObject enemy = Instantiate(enemyPrefab, spawn.position, Quaternion.identity);
+        Camera cam = Camera.main;
+        if (cam == null)
+            return;
+
+        float height = cam.orthographicSize * 2f;
+        float width = height * cam.aspect;
+        Vector3 camPos = cam.transform.position;
+        float minX = camPos.x - width / 2f;
+        float maxX = camPos.x + width / 2f;
+        float minY = camPos.y - height / 2f;
+        float maxY = camPos.y + height / 2f;
+        float offset = 1f;
+
+        Vector3 spawnPos = Vector3.zero;
+        switch (Random.Range(0, 4))
+        {
+            case 0:
+                spawnPos = new Vector3(minX - offset, Random.Range(minY, maxY), 0f);
+                break;
+            case 1:
+                spawnPos = new Vector3(maxX + offset, Random.Range(minY, maxY), 0f);
+                break;
+            case 2:
+                spawnPos = new Vector3(Random.Range(minX, maxX), maxY + offset, 0f);
+                break;
+            default:
+                spawnPos = new Vector3(Random.Range(minX, maxX), minY - offset, 0f);
+                break;
+        }
+
+        GameObject enemy = Instantiate(enemyPrefab, spawnPos, Quaternion.identity);
         EnemyHealth eh = enemy.GetComponent<EnemyHealth>();
         if (eh != null)
             eh.maxHealth = Mathf.RoundToInt(eh.maxHealth * GetDifficultyMultiplier());
         EnemyAI ai = enemy.GetComponent<EnemyAI>();
         if (ai != null)
             ai.damage = Mathf.RoundToInt(ai.damage * GetDifficultyMultiplier());
+
+        Transform player = GameObject.FindGameObjectWithTag("Player")?.transform;
+        if (player != null)
+        {
+            enemy.transform.up = (player.position - enemy.transform.position).normalized;
+            EnemyFollow follow = enemy.GetComponent<EnemyFollow>();
+            if (follow != null)
+                follow.player = player;
+        }
     }
 
     public void RegisterKill()


### PR DESCRIPTION
## Summary
- spawn enemies just outside the camera bounds
- remove the unused `spawnPoints` array
- orient new enemies toward the player and set `EnemyFollow` target

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68485f3dc53c8326ba6544b98557f975