### PR TITLE
Implement time scaling for level-up panel

### DIFF
--- a/Assets/LevelUpManager.cs
+++ b/Assets/LevelUpManager.cs
@@ -57,6 +57,7 @@ public class LevelUpManager : MonoBehaviour
             return;
 
         optionPanel.SetActive(true);
+        Time.timeScale = 0f;
 
         foreach (Transform child in optionPanel.transform)
             Destroy(child.gameObject);
@@ -83,6 +84,7 @@ public class LevelUpManager : MonoBehaviour
             if (text != null) text.text = up.label;
             btn.onClick.AddListener(() => {
                 up.apply();
+                Time.timeScale = 1f;
                 optionPanel.SetActive(false);
             });
         }


### PR DESCRIPTION
## Summary
- pause the game when level-up options are displayed
- resume normal time after selecting an upgrade

## Testing
- `npm test` *(fails: missing package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68487bc3f2488326b2e3ac860723e040