### PR TITLE
Add basic game over system

### DIFF
--- a/Assets/DifficultyManager.cs
+++ b/Assets/DifficultyManager.cs
@@ -27,6 +27,8 @@ public class DifficultyManager : MonoBehaviour
 
     void Update()
     {
+        if (GameOverManager.Instance != null && GameOverManager.Instance.IsGameOver)
+            return;
         if (Time.time >= nextSpawnTime)
         {
             SpawnEnemy();

--- a/Assets/EnemyAI.cs
+++ b/Assets/EnemyAI.cs
@@ -28,6 +28,8 @@ public class EnemyAI : MonoBehaviour
 
     void Update()
     {
+        if (GameOverManager.Instance != null && GameOverManager.Instance.IsGameOver)
+            return;
         if (player == null)
             return;
 
@@ -58,6 +60,8 @@ public class EnemyAI : MonoBehaviour
 
     void FixedUpdate()
     {
+        if (GameOverManager.Instance != null && GameOverManager.Instance.IsGameOver)
+            return;
         if (player == null)
             return;
 

--- a/Assets/EnemyFollow.cs
+++ b/Assets/EnemyFollow.cs
@@ -16,6 +16,9 @@ public class EnemyFollow : MonoBehaviour
 
     void Update()
     {
+        if (GameOverManager.Instance != null && GameOverManager.Instance.IsGameOver)
+            return;
+
         if (player != null)
         {
             Vector2 direction = (player.position - transform.position).normalized;
@@ -25,6 +28,9 @@ public class EnemyFollow : MonoBehaviour
 
     void FixedUpdate()
     {
+        if (GameOverManager.Instance != null && GameOverManager.Instance.IsGameOver)
+            return;
+
         rb.MovePosition(rb.position + movement * speed * Time.fixedDeltaTime);
     }
 

--- a/Assets/GameOverManager.cs
+++ b/Assets/GameOverManager.cs
@@ -1,0 +1,55 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+public class GameOverManager : MonoBehaviour
+{
+    public static GameOverManager Instance { get; private set; }
+
+    public GameObject gameOverUI;
+    public bool IsGameOver { get; private set; }
+
+    void Awake()
+    {
+        if (Instance == null)
+            Instance = this;
+        else
+            Destroy(gameObject);
+    }
+
+    void Start()
+    {
+        if (gameOverUI == null)
+            CreateDefaultUI();
+        if (gameOverUI != null)
+            gameOverUI.SetActive(false);
+    }
+
+    void CreateDefaultUI()
+    {
+        var canvasGO = new GameObject("GameOverCanvas");
+        var canvas = canvasGO.AddComponent<Canvas>();
+        canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+        canvasGO.AddComponent<CanvasScaler>();
+        canvasGO.AddComponent<GraphicRaycaster>();
+
+        gameOverUI = new GameObject("GameOverText");
+        gameOverUI.transform.SetParent(canvasGO.transform);
+        var text = gameOverUI.AddComponent<Text>();
+        text.alignment = TextAnchor.MiddleCenter;
+        text.font = Resources.GetBuiltinResource<Font>("Arial.ttf");
+        text.text = "Game Over";
+        RectTransform rt = gameOverUI.GetComponent<RectTransform>();
+        rt.anchorMin = new Vector2(0.5f, 0.5f);
+        rt.anchorMax = new Vector2(0.5f, 0.5f);
+        rt.sizeDelta = new Vector2(200, 100);
+    }
+
+    public void GameOver()
+    {
+        if (IsGameOver)
+            return;
+        IsGameOver = true;
+        if (gameOverUI != null)
+            gameOverUI.SetActive(true);
+    }
+}

--- a/Assets/PlayerAttack.cs
+++ b/Assets/PlayerAttack.cs
@@ -17,6 +17,9 @@ public class PlayerAttack : MonoBehaviour
 
     void Update()
     {
+        if (GameOverManager.Instance != null && GameOverManager.Instance.IsGameOver)
+            return;
+
         // Attack when the E key is pressed
         if (Input.GetKeyDown(KeyCode.E) && Time.time >= lastAttackTime + cooldownTime)
             Swing();

--- a/Assets/PlayerHealth.cs
+++ b/Assets/PlayerHealth.cs
@@ -24,8 +24,14 @@ public class PlayerHealth : MonoBehaviour
         if (currentHealth <= 0)
         {
             Debug.Log("Player Died!");
-            // Add death logic here later
+            OnDeath();
         }
+    }
+
+    void OnDeath()
+    {
+        if (GameOverManager.Instance != null)
+            GameOverManager.Instance.GameOver();
     }
 
     public void Heal(int amount)

--- a/Assets/PlayerMovement.cs
+++ b/Assets/PlayerMovement.cs
@@ -13,6 +13,9 @@ public class PlayerMovement : MonoBehaviour
 
     void Update()
     {
+        if (GameOverManager.Instance != null && GameOverManager.Instance.IsGameOver)
+            return;
+
         moveDirection.x = Input.GetAxisRaw("Horizontal");
         moveDirection.y = Input.GetAxisRaw("Vertical");
         moveDirection = moveDirection.normalized;
@@ -20,6 +23,9 @@ public class PlayerMovement : MonoBehaviour
 
     void FixedUpdate()
     {
+        if (GameOverManager.Instance != null && GameOverManager.Instance.IsGameOver)
+            return;
+
         rb.MovePosition(rb.position + moveDirection * moveSpeed * Time.fixedDeltaTime);
     }
 }


### PR DESCRIPTION
## Summary
- trigger OnDeath in `PlayerHealth` when health runs out
- create `GameOverManager` to show game over UI
- stop movement, attacks and enemy logic when game over
- halt enemy spawning after the player dies

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_68487c55fe288326b4de3ed87ca31a50