### PR TITLE
Fix dash upgrade showing repeatedly

### DIFF
--- a/Assets/Scripts/LevelUpManager.cs
+++ b/Assets/Scripts/LevelUpManager.cs
@@ -117,6 +117,8 @@ public class LevelUpManager : MonoBehaviour
                 break;
         }
 
+        xp?.RegisterUpgrade(choice);
+
         Debug.Log($"Applied upgrade: {choice}");
     }
 }

--- a/Assets/Scripts/PlayerExperience.cs
+++ b/Assets/Scripts/PlayerExperience.cs
@@ -21,6 +21,17 @@ public class PlayerExperience : MonoBehaviour
     /// </summary>
     public int XPToNextLevel => xpToLevel;
 
+    // track upgrades already chosen so we don't offer them again
+    private readonly HashSet<string> chosenUpgrades = new HashSet<string>();
+
+    /// <summary>
+    /// Record an upgrade choice so it won't be offered again.
+    /// </summary>
+    public void RegisterUpgrade(string name)
+    {
+        chosenUpgrades.Add(name);
+    }
+
     // the full list of possible upgrades
     private static readonly List<string> allUpgrades = new List<string>
     {
@@ -81,10 +92,13 @@ public class PlayerExperience : MonoBehaviour
         float dpm = m.damageTaken / elapsedMin;  // damage per minute
         float kpm = m.kills / elapsedMin;  // kills per minute
 
-        // 2) Build weighted list
+        // 2) Build weighted list excluding already chosen upgrades
         var weighted = new List<(string name, float w)>();
         foreach (var name in allUpgrades)
         {
+            if (chosenUpgrades.Contains(name))
+                continue;
+
             float weight = 1f;
 
             // bias toward more HP if taking lots of damage
@@ -107,7 +121,7 @@ public class PlayerExperience : MonoBehaviour
 
         // 3) Sample three distinct upgrades
         var chosen = new List<string>();
-        for (int pick = 0; pick < 3; pick++)
+        for (int pick = 0; pick < 3 && weighted.Count > 0; pick++)
         {
             // compute total weight
             float total = 0f;


### PR DESCRIPTION
## Summary
- track chosen upgrades in `PlayerExperience`
- remove already-chosen upgrades from level-up options
- notify `PlayerExperience` when an upgrade is selected

## Testing
- `npm --version`
- `dotnet --version`

------
https://chatgpt.com/codex/tasks/task_e_684c6e40765c83268713737526345bb0