### PR TITLE
Implement stun system for player bullets

### DIFF
--- a/Assets/Scripts/EnemyAI.cs
+++ b/Assets/Scripts/EnemyAI.cs
@@ -20,6 +20,7 @@ public class EnemyAI : MonoBehaviour
     Vector2 patrolDir;
     float nextPatrolChange;
     float lastAttackTime;
+    float stunTimer;
 
     enum State { Patrol, Chase }
     State currentState = State.Patrol;
@@ -35,6 +36,12 @@ public class EnemyAI : MonoBehaviour
     {
         if (GameOverManager.Instance != null && GameOverManager.Instance.IsGameOver) return;
         if (player == null) return;
+
+        if (stunTimer > 0f)
+        {
+            stunTimer -= Time.deltaTime;
+            return;
+        }
 
         float dist = Vector2.Distance(player.position, transform.position);
 
@@ -57,6 +64,9 @@ public class EnemyAI : MonoBehaviour
     {
         if (GameOverManager.Instance != null && GameOverManager.Instance.IsGameOver) return;
         if (player == null) return;
+
+        if (stunTimer > 0f)
+            return;
 
         if (currentState == State.Patrol)
             rb.MovePosition(rb.position + patrolDir * moveSpeed * Time.fixedDeltaTime);
@@ -114,5 +124,10 @@ public class EnemyAI : MonoBehaviour
     {
         Gizmos.color = Color.yellow;
         Gizmos.DrawWireSphere(transform.position, chaseRange);
+    }
+
+    public void ApplyStun(float duration)
+    {
+        stunTimer = Mathf.Max(stunTimer, duration);
     }
 }

--- a/Assets/Scripts/LevelUpManager.cs
+++ b/Assets/Scripts/LevelUpManager.cs
@@ -108,8 +108,11 @@ public class LevelUpManager : MonoBehaviour
                 break;
 
             case "Kill: AoE Blast":
-            case "On Hit: 10% Stun":
                 Debug.LogWarning($"Upgrade '{choice}' not implemented yet.");
+                break;
+
+            case "On Hit: 10% Stun":
+                stats.stunChance = 0.10f;
                 break;
 
             default:

--- a/Assets/Scripts/PlayerBullet.cs
+++ b/Assets/Scripts/PlayerBullet.cs
@@ -8,6 +8,7 @@ public class PlayerBullet : MonoBehaviour
     [HideInInspector] public float critChance = 0f;
     [HideInInspector] public float critMultiplier = 1f;
     [HideInInspector] public float lifeStealFrac = 0f;
+    [HideInInspector] public float stunChance = 0f;
     [HideInInspector] public bool piercing = false;
     [HideInInspector] public int shieldHits = 0;
 
@@ -38,14 +39,21 @@ public class PlayerBullet : MonoBehaviour
         if (lifeStealFrac > 0f && TryGetComponent(out PlayerHealth ph))
             ph.Heal(Mathf.RoundToInt(finalDmg * lifeStealFrac));
 
-        // 4) ShieldHits on player bullets (rarely used)
+        // 4) Chance to stun
+        if (stunChance > 0f && Random.value < stunChance)
+        {
+            var ai = other.GetComponent<EnemyAI>();
+            ai?.ApplyStun(0.5f);
+        }
+
+        // 5) ShieldHits on player bullets (rarely used)
         if (shieldHits > 0)
         {
             shieldHits--;
             return;
         }
 
-        // 5) Destroy if not piercing
+        // 6) Destroy if not piercing
         if (!piercing)
             Destroy(gameObject);
     }

--- a/Assets/Scripts/PlayerShoot.cs
+++ b/Assets/Scripts/PlayerShoot.cs
@@ -69,6 +69,7 @@ public class PlayerShoot : MonoBehaviour
                 pb.critChance = stats.critChance;
                 pb.critMultiplier = stats.critMultiplier;
                 pb.lifeStealFrac = stats.lifeStealFraction;
+                pb.stunChance = stats.stunChance;
                 pb.piercing = stats.piercingBullets;
                 pb.shieldHits = stats.shieldHits;
             }

--- a/Assets/Scripts/PlayerStats.cs
+++ b/Assets/Scripts/PlayerStats.cs
@@ -12,6 +12,7 @@ public class PlayerStats : MonoBehaviour
     public float critChance = 0f;        // +15% Crit Chance
     public float critMultiplier = 2f;    // +150% Crit Damage
     public float lifeStealFraction = 0f; // 5% Life Steal
+    public float stunChance = 0f;        // Chance to stun on hit
 
     [Header("Fire Rate")]
     public float fireRateMultiplier = 1f; // +10% Attack Speed


### PR DESCRIPTION
## Summary
- add `stunChance` stat to player bullets and player stats
- allow LevelUp upgrade to enable 10% stun chance
- propagate stun stats when firing bullets
- enemies can now be stunned via `ApplyStun`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ce3a100388326a8516179eef80f8a