### PR TITLE
Implement kill-triggered AoE burst

### DIFF
--- a/Assets/Prefabs/AoEBurst.prefab
+++ b/Assets/Prefabs/AoEBurst.prefab
@@ -1,0 +1,52 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &100000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 100001}
+  - component: {fileID: 100002}
+  - component: {fileID: 100003}
+  m_Layer: 0
+  m_Name: AoEBurst
+  m_TagString: Untagged
+  m_IsActive: 1
+--- !u!4 &100001
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100000}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+--- !u!212 &100002
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100000}
+  m_IsTrigger: 1
+  m_Radius: 1
+--- !u!114 &100003
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100000}
+  m_Enabled: 1
+  m_Script: {fileID: 11500000, guid: 679a856f90464469b649749a8e1aaf61, type: 3}
+  damage: 1
+  radius: 1
+  enemyLayers:
+    serializedVersion: 2
+    m_Bits: 8

--- a/Assets/Prefabs/AoEBurst.prefab.meta
+++ b/Assets/Prefabs/AoEBurst.prefab.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: be708c5be9f54f55bd1d889fb78e0c27

--- a/Assets/Scripts/AoEBurst.cs
+++ b/Assets/Scripts/AoEBurst.cs
@@ -1,0 +1,37 @@
+using UnityEngine;
+
+[RequireComponent(typeof(CircleCollider2D))]
+public class AoEBurst : MonoBehaviour
+{
+    [Tooltip("Damage dealt to enemies inside the radius")] public int damage = 1;
+    [Tooltip("Radius of the AoE burst")] public float radius = 1f;
+    [Tooltip("Layer mask for enemies")] public LayerMask enemyLayers;
+
+    void Start()
+    {
+        DamageEnemies();
+        // auto-destroy after particle duration if any
+        float life = 1f;
+        var ps = GetComponent<ParticleSystem>();
+        if (ps != null)
+            life = ps.main.duration;
+        Destroy(gameObject, life);
+    }
+
+    private void DamageEnemies()
+    {
+        Collider2D[] hits = Physics2D.OverlapCircleAll(transform.position, radius, enemyLayers);
+        foreach (var hit in hits)
+        {
+            var eh = hit.GetComponent<EnemyHealth>();
+            if (eh != null)
+                eh.TakeDamage(damage);
+        }
+    }
+
+    void OnDrawGizmosSelected()
+    {
+        Gizmos.color = Color.red;
+        Gizmos.DrawWireSphere(transform.position, radius);
+    }
+}

--- a/Assets/Scripts/AoEBurst.cs.meta
+++ b/Assets/Scripts/AoEBurst.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 679a856f90464469b649749a8e1aaf61

--- a/Assets/Scripts/EnemyHealth.cs
+++ b/Assets/Scripts/EnemyHealth.cs
@@ -52,6 +52,19 @@ public class EnemyHealth : MonoBehaviour
         // 2) Register kill
         DifficultyManager.Instance?.RegisterKill();
 
+        // Trigger AoE burst if player has the upgrade
+        var player = GameObject.FindWithTag("Player");
+        if (player != null)
+        {
+            var stats = player.GetComponent<PlayerStats>();
+            if (stats != null && stats.killAoE)
+            {
+                var prefab = Resources.Load<GameObject>("AoEBurst");
+                if (prefab != null)
+                    Instantiate(prefab, transform.position, Quaternion.identity);
+            }
+        }
+
         // 3) Tear down
         Destroy(gameObject);
 

--- a/Assets/Scripts/LevelUpManager.cs
+++ b/Assets/Scripts/LevelUpManager.cs
@@ -108,7 +108,7 @@ public class LevelUpManager : MonoBehaviour
                 break;
 
             case "Kill: AoE Blast":
-                Debug.LogWarning($"Upgrade '{choice}' not implemented yet.");
+                stats.killAoE = true;
                 break;
 
             case "On Hit: 10% Stun":

--- a/Assets/Scripts/PlayerStats.cs
+++ b/Assets/Scripts/PlayerStats.cs
@@ -21,5 +21,8 @@ public class PlayerStats : MonoBehaviour
     public bool dashUnlocked = false;     // Unlock Dash Ability
     public float healthRegenPerSec = 0f;  // +20% Health Regen
 
+    [Header("Kill Effects")]
+    public bool killAoE = false;          // Trigger AoE burst on kill
+
     // (Optional) you can tick “Apply regen per second” in Update elsewhere
 }


### PR DESCRIPTION
## Summary
- add new `AoEBurst` prefab and damaging script
- track AoE unlock in `PlayerStats`
- spawn AoE on enemy death when upgrade active
- allow "Kill: AoE Blast" upgrade to enable AoE bursts

## Testing
- `true` *(no tests provided)*


------
https://chatgpt.com/codex/tasks/task_e_684ce511de84832693ac59f6d4917b30