### PR TITLE
Implement bullet owner and update lifesteal

### DIFF
--- a/Assets/Scripts/PlayerBullet.cs
+++ b/Assets/Scripts/PlayerBullet.cs
@@ -5,6 +5,9 @@ public class PlayerBullet : MonoBehaviour
     [Tooltip("Base damage BEFORE multipliers")]
     public int damage = 1;
 
+    // reference back to the player that fired this bullet
+    public PlayerHealth owner;
+
     [HideInInspector] public float critChance = 0f;
     [HideInInspector] public float critMultiplier = 1f;
     [HideInInspector] public float lifeStealFrac = 0f;
@@ -36,8 +39,8 @@ public class PlayerBullet : MonoBehaviour
         eh.TakeDamage(finalDmg);
 
         // 3) Life steal
-        if (lifeStealFrac > 0f && TryGetComponent(out PlayerHealth ph))
-            ph.Heal(Mathf.RoundToInt(finalDmg * lifeStealFrac));
+        if (lifeStealFrac > 0f)
+            owner?.Heal(Mathf.RoundToInt(finalDmg * lifeStealFrac));
 
         // 4) Chance to stun
         if (stunChance > 0f && Random.value < stunChance)

--- a/Assets/Scripts/PlayerShoot.cs
+++ b/Assets/Scripts/PlayerShoot.cs
@@ -63,15 +63,19 @@ public class PlayerShoot : MonoBehaviour
 
             // pass stats into the bullet
             var pb = b.GetComponent<PlayerBullet>();
-            if (pb != null && stats != null)
+            if (pb != null)
             {
-                pb.damage = Mathf.RoundToInt(pb.damage * stats.damageMultiplier);
-                pb.critChance = stats.critChance;
-                pb.critMultiplier = stats.critMultiplier;
-                pb.lifeStealFrac = stats.lifeStealFraction;
-                pb.stunChance = stats.stunChance;
-                pb.piercing = stats.piercingBullets;
-                pb.shieldHits = stats.shieldHits;
+                pb.owner = GetComponent<PlayerHealth>();
+                if (stats != null)
+                {
+                    pb.damage = Mathf.RoundToInt(pb.damage * stats.damageMultiplier);
+                    pb.critChance = stats.critChance;
+                    pb.critMultiplier = stats.critMultiplier;
+                    pb.lifeStealFrac = stats.lifeStealFraction;
+                    pb.stunChance = stats.stunChance;
+                    pb.piercing = stats.piercingBullets;
+                    pb.shieldHits = stats.shieldHits;
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- add an `owner` reference to `PlayerBullet`
- assign the owner when shooting bullets in `PlayerShoot`
- use the owner reference for life steal instead of searching components

## Testing
- `echo no tests`
- `mcs -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ce6b1906c8326960561c1577fccb0