### PR TITLE
Add teleporting enemy type

### DIFF
--- a/Assets/Prefabs/TeleportingEnemy.prefab
+++ b/Assets/Prefabs/TeleportingEnemy.prefab
@@ -1,0 +1,193 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &3127573181285724724
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5290258496262859168}
+  - component: {fileID: 6247144505099225956}
+  - component: {fileID: 124980383684009217}
+  - component: {fileID: 7606681515181000948}
+  - component: {fileID: 2026848764904998958}
+  - component: {fileID: -5090483732443940068}
+  m_Layer: 3
+  m_Name: TeleportingEnemy
+  m_TagString: Enemy
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5290258496262859168
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3127573181285724724}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 2.56, y: 0.5, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &6247144505099225956
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3127573181285724724}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: -2413806693520163455, guid: a86470a33a6bf42c4b3595704624658b, type: 3}
+  m_Color: {r: 0.7433963, g: 0.16130286, b: 0.16130286, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!50 &124980383684009217
+Rigidbody2D:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3127573181285724724}
+  m_BodyType: 1
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_GravityScale: 0
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_Interpolate: 1
+  m_SleepingMode: 1
+  m_CollisionDetection: 1
+  m_Constraints: 4
+--- !u!58 &7606681515181000948
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3127573181285724724}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 0, y: 0}
+  m_Radius: 0.55
+--- !u!114 &2026848764904998958
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3127573181285724724}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2706409e21ea58f48abcc038d47aa138, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  maxHealth: 3
+  experienceReward: 1
+  xpPickupPrefab: {fileID: 8365154387049940543, guid: 2a2e33d7d9298d5458fce91be3aa10ce, type: 3}
+  healthPickupPrefab: {fileID: 8365154387049940543, guid: 9ca8565c5e857f74d920b1cd31d620c3, type: 3}
+  healthDropChance: 0.1
+  damageTextPrefab: {fileID: 0}
+--- !u!114 &-5090483732443940068
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3127573181285724724}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6ba33a5217f142f19731196a1bf46df9, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  teleportInterval: 3
+  teleportRange: 5
+  attackCooldown: 1
+  damage: 1
+  playerLayer:
+    serializedVersion: 2
+    m_Bits: 64

--- a/Assets/Prefabs/TeleportingEnemy.prefab.meta
+++ b/Assets/Prefabs/TeleportingEnemy.prefab.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 99c0d99ed92e43f4bbd81f61cbc214ac

--- a/Assets/Scripts/DifficultyManager.cs
+++ b/Assets/Scripts/DifficultyManager.cs
@@ -7,6 +7,7 @@ public class DifficultyManager : MonoBehaviour
     [Header("Spawn Settings")]
     public GameObject meleePrefab;
     public GameObject shooterPrefab;
+    public GameObject teleporterPrefab;
     [Tooltip("Prefab for the mini-boss.")]
     public GameObject bossPrefab;
     [Tooltip("Seconds until boss appears.")]
@@ -68,7 +69,14 @@ public class DifficultyManager : MonoBehaviour
 
     private void SpawnEnemy()
     {
-        GameObject prefab = (Random.value < 0.5f) ? meleePrefab : shooterPrefab;
+        GameObject prefab;
+        float roll = Random.value;
+        if (roll < 0.33f)
+            prefab = meleePrefab;
+        else if (roll < 0.66f)
+            prefab = shooterPrefab;
+        else
+            prefab = teleporterPrefab;
         if (prefab == null) return;
 
         Vector3 pos = GetEdgeSpawnPosition();

--- a/Assets/Scripts/TeleportingEnemyAI.cs
+++ b/Assets/Scripts/TeleportingEnemyAI.cs
@@ -1,0 +1,74 @@
+using UnityEngine;
+
+[RequireComponent(typeof(Rigidbody2D))]
+public class TeleportingEnemyAI : MonoBehaviour
+{
+    [Header("Teleport Settings")]
+    public float teleportInterval = 3f;
+    public float teleportRange = 5f;
+
+    [Header("Combat")]
+    public float attackCooldown = 1f;
+    public int damage = 1;
+    public LayerMask playerLayer;
+
+    private Transform player;
+    private float nextTeleportTime;
+    private float lastAttackTime;
+    private Rigidbody2D rb;
+
+    void Start()
+    {
+        player = GameObject.FindGameObjectWithTag("Player")?.transform;
+        rb = GetComponent<Rigidbody2D>();
+        nextTeleportTime = Time.time + teleportInterval;
+    }
+
+    void Update()
+    {
+        if (player == null) return;
+        if (GameOverManager.Instance != null && GameOverManager.Instance.IsGameOver)
+            return;
+
+        if (Time.time >= nextTeleportTime)
+        {
+            TeleportNearPlayer();
+            nextTeleportTime = Time.time + teleportInterval;
+        }
+    }
+
+    void TeleportNearPlayer()
+    {
+        Vector2 offset = Random.insideUnitCircle.normalized * teleportRange;
+        rb.position = (Vector2)player.position + offset;
+    }
+
+    void OnCollisionEnter2D(Collision2D col)
+    {
+        TryDealMelee(col.collider);
+    }
+
+    void OnCollisionStay2D(Collision2D col)
+    {
+        TryDealMelee(col.collider);
+    }
+
+    void TryDealMelee(Collider2D col)
+    {
+        if (((1 << col.gameObject.layer) & playerLayer) == 0)
+            return;
+        if (Time.time < lastAttackTime + attackCooldown)
+            return;
+        lastAttackTime = Time.time;
+
+        var ph = col.GetComponent<PlayerHealth>();
+        if (ph != null)
+            ph.TakeDamage(damage);
+    }
+
+    void OnDrawGizmosSelected()
+    {
+        Gizmos.color = Color.cyan;
+        Gizmos.DrawWireSphere(transform.position, teleportRange);
+    }
+}

--- a/Assets/Scripts/TeleportingEnemyAI.cs.meta
+++ b/Assets/Scripts/TeleportingEnemyAI.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6ba33a5217f142f19731196a1bf46df9


### PR DESCRIPTION
## Summary
- create `TeleportingEnemyAI` for enemies that periodically teleport
- add TeleportingEnemy prefab using the new behaviour
- allow DifficultyManager to spawn the new enemy type

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_684cf10cc49c832681207f574cee9554