### PR TITLE
Add accuracy metrics for dynamic difficulty

### DIFF
--- a/Assets/Scripts/DifficultyManager.cs
+++ b/Assets/Scripts/DifficultyManager.cs
@@ -28,6 +28,11 @@ public class DifficultyManager : MonoBehaviour
     [Tooltip("Weight for time spent chasing vs. attacking.")]
     public float chaseWeight = 0.5f;
 
+    [Tooltip("Multiplier added based on shot accuracy (0-1).")]
+    public float accuracyWeight = 1f;
+    [Tooltip("Multiplier added per second faster kill time.")]
+    public float killTimeWeight = 1f;
+
     private float nextSpawnTime;
     private bool bossSpawned = false;
     private int enemiesDefeated;
@@ -173,14 +178,19 @@ public class DifficultyManager : MonoBehaviour
 
         float damageFactor = 0f;
         float chaseFactor = 0f;
+        float accuracyFactor = 0f;
+        float killTimeFactor = 0f;
         var m = RunMetrics.Instance;
         if (m != null)
         {
             damageFactor = m.damageTaken * damageWeight;
             float ratio = m.timeInChase / Mathf.Max(1f, m.timeInAttack);
             chaseFactor = ratio * chaseWeight;
+            accuracyFactor = m.Accuracy * accuracyWeight;
+            if (m.AverageKillTime > 0f)
+                killTimeFactor = killTimeWeight / m.AverageKillTime;
         }
 
-        return 1f + timeFactor + killFactor + damageFactor + chaseFactor;
+        return 1f + timeFactor + killFactor + damageFactor + chaseFactor + accuracyFactor + killTimeFactor;
     }
 }

--- a/Assets/Scripts/EnemyHealth.cs
+++ b/Assets/Scripts/EnemyHealth.cs
@@ -17,9 +17,12 @@ public class EnemyHealth : MonoBehaviour
     [Header("Feedback")]
     public FloatingDamageText damageTextPrefab;
 
+    private float spawnTime;
+
     void Start()
     {
         currentHealth = maxHealth;
+        spawnTime = Time.time;
     }
 
     public void TakeDamage(int amount)
@@ -39,6 +42,7 @@ public class EnemyHealth : MonoBehaviour
 
     void Die()
     {
+        RunMetrics.Instance?.RegisterKillTime(Time.time - spawnTime);
         // 1) Spawn health or XP
         if (Random.value < healthDropChance && healthPickupPrefab != null)
             Instantiate(healthPickupPrefab, transform.position, Quaternion.identity);

--- a/Assets/Scripts/PlayerBullet.cs
+++ b/Assets/Scripts/PlayerBullet.cs
@@ -30,6 +30,8 @@ public class PlayerBullet : MonoBehaviour
         var eh = other.GetComponent<EnemyHealth>();
         if (eh == null) return;
 
+        RunMetrics.Instance?.RegisterHit();
+
         // 1) Calculate crit
         int finalDmg = damage;
         if (Random.value < critChance)

--- a/Assets/Scripts/PlayerShoot.cs
+++ b/Assets/Scripts/PlayerShoot.cs
@@ -57,6 +57,7 @@ public class PlayerShoot : MonoBehaviour
             spawnPos.z = 2f;
 
             GameObject b = Instantiate(bulletPrefab, spawnPos, rot);
+            RunMetrics.Instance?.RegisterShot();
             var rb = b.GetComponent<Rigidbody2D>();
             if (rb != null)
                 rb.linearVelocity = rot * Vector3.up * bulletSpeed;

--- a/Assets/Scripts/RunMetrics.cs
+++ b/Assets/Scripts/RunMetrics.cs
@@ -14,6 +14,11 @@ public class RunMetrics : MonoBehaviour
     [HideInInspector] public float timeInChase = 0f;
     [HideInInspector] public float timeInAttack = 0f;
 
+    // New metrics for accuracy and kill time
+    [HideInInspector] public int shotsFired = 0;
+    [HideInInspector] public int shotsHit = 0;
+    [HideInInspector] public float totalKillTime = 0f;
+
     void Awake()
     {
         if (Instance == null)
@@ -60,6 +65,40 @@ public class RunMetrics : MonoBehaviour
     {
         timeInAttack += deltaSeconds;
     }
+
+    /// <summary>
+    /// Call when the player fires a projectile.
+    /// </summary>
+    public void RegisterShot()
+    {
+        shotsFired++;
+    }
+
+    /// <summary>
+    /// Call when a projectile successfully hits an enemy.
+    /// </summary>
+    public void RegisterHit()
+    {
+        shotsHit++;
+    }
+
+    /// <summary>
+    /// Record the time from spawn to kill for an enemy.
+    /// </summary>
+    public void RegisterKillTime(float seconds)
+    {
+        totalKillTime += seconds;
+    }
+
+    /// <summary>
+    /// Current shot accuracy ratio (0-1).
+    /// </summary>
+    public float Accuracy => shotsFired > 0 ? (float)shotsHit / shotsFired : 0f;
+
+    /// <summary>
+    /// Average time it takes to kill an enemy.
+    /// </summary>
+    public float AverageKillTime => kills > 0 ? totalKillTime / kills : 0f;
 
     /// <summary>
     /// Optional hook to snapshot or process metrics before sampling.

--- a/Assets/Scripts/RunMetricsLogger.cs
+++ b/Assets/Scripts/RunMetricsLogger.cs
@@ -19,8 +19,8 @@ public class RunMetricsLogger : MonoBehaviour
         if (m == null)
             return;
 
-        string header = "Kills,DamageTaken,TimeInChase,TimeInAttack,PUPEarned";
-        string line = $"{m.kills},{m.damageTaken},{m.timeInChase:F2},{m.timeInAttack:F2},{pupEarned}";
+        string header = "Kills,DamageTaken,TimeInChase,TimeInAttack,ShotsFired,ShotsHit,AvgKillTime,PUPEarned";
+        string line = $"{m.kills},{m.damageTaken},{m.timeInChase:F2},{m.timeInAttack:F2},{m.shotsFired},{m.shotsHit},{m.AverageKillTime:F2},{pupEarned}";
 
         bool exists = File.Exists(CsvPath);
         using (var writer = new StreamWriter(CsvPath, append: true))


### PR DESCRIPTION
## Summary
- track shots fired, hits and kill time in `RunMetrics`
- log new metrics to the CSV logger
- expose weights for accuracy and kill time on `DifficultyManager`
- factor accuracy and kill speed into difficulty multiplier
- record player shots and hits
- record enemy spawn time for kill time tracking

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cfc6565ac8326bd9280893bfde884