### PR TITLE
Implement BossAI with phased attacks

### DIFF
--- a/Assets/Prefabs/BossEnemy.prefab
+++ b/Assets/Prefabs/BossEnemy.prefab
@@ -194,7 +194,7 @@ MonoBehaviour:
   healthPickupPrefab: {fileID: 8365154387049940543, guid: 9ca8565c5e857f74d920b1cd31d620c3, type: 3}
   healthDropChance: 0
   damageTextPrefab: {fileID: 0}
---- !u!114 &-7827119864390000583
+--- !u!114 &-2437136510676715986
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -203,14 +203,12 @@ MonoBehaviour:
   m_GameObject: {fileID: 3127573181285724724}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e74b5e6ecae44530aa30b03928efb4d5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  chaseRange: 200
-  moveSpeed: 1.58
-  patrolChangeInterval: 2
-  attackCooldown: 1
-  damage: 1
-  playerLayer:
-    serializedVersion: 2
-    m_Bits: 64
+  m_Script: {fileID: 11500000, guid: c6bdb587dd99462f9aa1550cdfe84be4, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  minionPrefab: {fileID: 3127573181285724724, guid: 2e616943950183845875b29ed980d7f0, type: 3}
+  areaAttackPrefab: {fileID: 100000, guid: be708c5be9f54f55bd1d889fb78e0c27, type: 3}
+  summonCooldown: 5
+  areaCooldown: 8
+  enragedThreshold: 0.5
+  enragedRate: 0.5

--- a/Assets/Scripts/BossAI.cs
+++ b/Assets/Scripts/BossAI.cs
@@ -1,0 +1,73 @@
+using UnityEngine;
+
+[RequireComponent(typeof(EnemyHealth))]
+public class BossAI : MonoBehaviour
+{
+    [Header("Prefabs")] 
+    public GameObject minionPrefab;
+    public GameObject areaAttackPrefab;
+
+    [Header("Cooldowns")]
+    public float summonCooldown = 5f;
+    public float areaCooldown = 8f;
+
+    [Header("Phase Settings")]
+    [Tooltip("Fraction of max HP when the boss becomes enraged")] 
+    public float enragedThreshold = 0.5f;
+    [Tooltip("Multiplier applied to cooldowns when enraged")] 
+    public float enragedRate = 0.5f;
+
+    private EnemyHealth health;
+    private float nextSummon;
+    private float nextArea;
+    private bool enraged;
+
+    void Start()
+    {
+        health = GetComponent<EnemyHealth>();
+        nextSummon = Time.time + summonCooldown;
+        nextArea = Time.time + areaCooldown;
+    }
+
+    void Update()
+    {
+        if (GameOverManager.Instance != null && GameOverManager.Instance.IsGameOver)
+            return;
+
+        if (health != null && !enraged && health.CurrentHealth <= health.maxHealth * enragedThreshold)
+        {
+            enraged = true;
+            summonCooldown *= enragedRate;
+            areaCooldown *= enragedRate;
+        }
+
+        if (Time.time >= nextSummon)
+        {
+            SummonMinions();
+            nextSummon = Time.time + summonCooldown;
+        }
+
+        if (Time.time >= nextArea)
+        {
+            AreaAttack();
+            nextArea = Time.time + areaCooldown;
+        }
+    }
+
+    void SummonMinions()
+    {
+        if (minionPrefab == null) return;
+        const int count = 3;
+        for (int i = 0; i < count; i++)
+        {
+            Vector2 offset = Random.insideUnitCircle * 1.5f;
+            Instantiate(minionPrefab, (Vector2)transform.position + offset, Quaternion.identity);
+        }
+    }
+
+    void AreaAttack()
+    {
+        if (areaAttackPrefab == null) return;
+        Instantiate(areaAttackPrefab, transform.position, Quaternion.identity);
+    }
+}

--- a/Assets/Scripts/BossAI.cs.meta
+++ b/Assets/Scripts/BossAI.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c6bdb587dd99462f9aa1550cdfe84be4

--- a/Assets/Scripts/EnemyHealth.cs
+++ b/Assets/Scripts/EnemyHealth.cs
@@ -5,6 +5,7 @@ public class EnemyHealth : MonoBehaviour
     [Header("Health Settings")]
     public int maxHealth = 3;
     private int currentHealth;
+    public int CurrentHealth => currentHealth;
 
     [Header("Drop Settings")]
     [Tooltip("XP orb prefab")]


### PR DESCRIPTION
## Summary
- implement `BossAI` for minion summons, area attacks and an enraged state
- expose `EnemyHealth.CurrentHealth`
- attach `BossAI` to `BossEnemy.prefab` and set defaults

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684cfd621f00832683f3c8159f1d2be8