### PR TITLE
Add behavior tree enemy

### DIFF
--- a/Assets/Prefabs/BehaviorEnemy.prefab
+++ b/Assets/Prefabs/BehaviorEnemy.prefab
@@ -1,0 +1,229 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &3127573181285724724
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5290258496262859168}
+  - component: {fileID: 6247144505099225956}
+  - component: {fileID: 124980383684009217}
+  - component: {fileID: 7606681515181000948}
+  - component: {fileID: 1111111111111111111}
+  - component: {fileID: 2026848764904998958}
+  - component: {fileID: -7827119864390000583}
+  - component: {fileID: -5649553040077235423}
+  m_Layer: 3
+  m_Name: BehaviorEnemy
+  m_TagString: Enemy
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5290258496262859168
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3127573181285724724}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 2.56, y: 0.5, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &6247144505099225956
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3127573181285724724}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: -2413806693520163455, guid: a86470a33a6bf42c4b3595704624658b, type: 3}
+  m_Color: {r: 0.7433963, g: 0.16130286, b: 0.16130286, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!50 &124980383684009217
+Rigidbody2D:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3127573181285724724}
+  m_BodyType: 1
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_GravityScale: 0
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_Interpolate: 1
+  m_SleepingMode: 1
+  m_CollisionDetection: 1
+  m_Constraints: 4
+--- !u!58 &7606681515181000948
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3127573181285724724}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 0, y: 0}
+  m_Radius: 0.55
+--- !u!195 &1111111111111111111
+NavMeshAgent:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3127573181285724724}
+  m_Enabled: 1
+  m_AgentTypeID: 0
+  m_Radius: 0.5
+  m_Speed: 2
+  m_Acceleration: 8
+  m_AngularSpeed: 120
+  m_StoppingDistance: 0
+  m_AutoTraverseOffMeshLink: 1
+  m_AutoBraking: 1
+  m_AutoRepath: 1
+  m_Height: 2
+  m_BaseOffset: 0
+  m_WalkableMask: 4294967295
+  m_ObstacleAvoidanceType: 4
+--- !u!114 &2026848764904998958
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3127573181285724724}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2706409e21ea58f48abcc038d47aa138, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  maxHealth: 3
+  experienceReward: 1
+  xpPickupPrefab: {fileID: 8365154387049940543, guid: 2a2e33d7d9298d5458fce91be3aa10ce, type: 3}
+  healthPickupPrefab: {fileID: 8365154387049940543, guid: 9ca8565c5e857f74d920b1cd31d620c3, type: 3}
+  healthDropChance: 0.1
+  damageTextPrefab: {fileID: 0}
+--- !u!114 &-7827119864390000583
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3127573181285724724}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2b741ac581d8468098b79449fabb9936, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  chaseRange: 10
+  moveSpeed: 2
+  patrolChangeInterval: 2
+  attackCooldown: 1
+  damage: 1
+  playerLayer:
+    serializedVersion: 2
+  m_Bits: 64
+--- !u!114 &-5649553040077235423
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3127573181285724724}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c027ffc36cac4e12ad74f08fba3f1281, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:

--- a/Assets/Prefabs/BehaviorEnemy.prefab.meta
+++ b/Assets/Prefabs/BehaviorEnemy.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 632499a7104a43ecbc87d6ee96aa49b5
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/BehaviorEnemyAI.cs
+++ b/Assets/Scripts/BehaviorEnemyAI.cs
@@ -1,0 +1,126 @@
+using UnityEngine;
+using UnityEngine.AI;
+
+[RequireComponent(typeof(Rigidbody2D), typeof(Collider2D), typeof(NavMeshAgent), typeof(BehaviorTreeRunner))]
+public class BehaviorEnemyAI : MonoBehaviour
+{
+    [Header("Movement & Detection")]
+    public float chaseRange = 8f;
+    public float attackRange = 1.5f;
+    public float retreatDuration = 1f;
+    public float moveSpeed = 2f;
+    public float patrolChangeInterval = 2f;
+
+    [Header("Combat")]
+    public float attackCooldown = 1f;
+    public int damage = 1;
+    public LayerMask playerLayer;
+
+    Rigidbody2D rb;
+    NavMeshAgent agent;
+    Transform player;
+    Vector2 patrolDir;
+    float nextPatrolChange;
+    float lastAttackTime;
+    float retreatEnd;
+
+    void Start()
+    {
+        rb = GetComponent<Rigidbody2D>();
+        agent = GetComponent<NavMeshAgent>();
+        if (agent != null)
+        {
+            agent.updateRotation = false;
+            agent.updateUpAxis = false;
+            agent.speed = moveSpeed;
+            agent.isStopped = true;
+        }
+        player = GameObject.FindGameObjectWithTag("Player")?.transform;
+        ChooseNewPatrolDirection();
+
+        var runner = GetComponent<BehaviorTreeRunner>();
+        runner.root = BuildTree();
+    }
+
+    BTNode BuildTree()
+    {
+        return new Sequence(new BTNode[] {
+            new ActionNode(Patrol),
+            new ActionNode(Chase),
+            new ActionNode(Attack),
+            new ActionNode(Retreat)
+        });
+    }
+
+    BTNode.State Patrol()
+    {
+        if (player == null) return BTNode.State.Failure;
+        float dist = Vector2.Distance(player.position, transform.position);
+        if (dist <= chaseRange)
+            return BTNode.State.Success;
+
+        if (Time.time >= nextPatrolChange)
+            ChooseNewPatrolDirection();
+
+        if (agent != null)
+            agent.isStopped = true;
+        rb.MovePosition(rb.position + patrolDir * moveSpeed * Time.deltaTime);
+        return BTNode.State.Running;
+    }
+
+    BTNode.State Chase()
+    {
+        if (player == null) return BTNode.State.Failure;
+        float dist = Vector2.Distance(player.position, transform.position);
+        if (dist > chaseRange)
+            return BTNode.State.Failure;
+        if (dist <= attackRange)
+            return BTNode.State.Success;
+
+        if (agent != null)
+        {
+            agent.isStopped = false;
+            agent.SetDestination(player.position);
+        }
+        else
+        {
+            Vector2 dir = ((Vector2)player.position - rb.position).normalized;
+            rb.MovePosition(rb.position + dir * moveSpeed * Time.deltaTime);
+        }
+        return BTNode.State.Running;
+    }
+
+    BTNode.State Attack()
+    {
+        if (player == null) return BTNode.State.Failure;
+        float dist = Vector2.Distance(player.position, transform.position);
+        if (dist > attackRange)
+            return BTNode.State.Failure;
+        if (Time.time < lastAttackTime + attackCooldown)
+            return BTNode.State.Running;
+        lastAttackTime = Time.time;
+        if (player.TryGetComponent<PlayerHealth>(out var ph))
+            ph.TakeDamage(damage);
+        retreatEnd = Time.time + retreatDuration;
+        return BTNode.State.Success;
+    }
+
+    BTNode.State Retreat()
+    {
+        if (player == null) return BTNode.State.Failure;
+        if (Time.time >= retreatEnd)
+            return BTNode.State.Success;
+        if (agent != null)
+            agent.isStopped = true;
+        Vector2 dir = ((Vector2)transform.position - (Vector2)player.position).normalized;
+        rb.MovePosition(rb.position + dir * moveSpeed * Time.deltaTime);
+        return BTNode.State.Running;
+    }
+
+    void ChooseNewPatrolDirection()
+    {
+        float ang = Random.Range(0f, Mathf.PI * 2f);
+        patrolDir = new Vector2(Mathf.Cos(ang), Mathf.Sin(ang));
+        nextPatrolChange = Time.time + patrolChangeInterval;
+    }
+}

--- a/Assets/Scripts/BehaviorEnemyAI.cs.meta
+++ b/Assets/Scripts/BehaviorEnemyAI.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2b741ac581d8468098b79449fabb9936

--- a/Assets/Scripts/BehaviorTree.meta
+++ b/Assets/Scripts/BehaviorTree.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 59ba56bb4c6e4d4c93741dc268891fe5
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/BehaviorTree/BTNode.cs
+++ b/Assets/Scripts/BehaviorTree/BTNode.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+
+public abstract class BTNode
+{
+    public enum State { Success, Failure, Running }
+    public abstract State Tick();
+}
+
+public class Sequence : BTNode
+{
+    private readonly List<BTNode> children;
+    private int index = 0;
+
+    public Sequence(IEnumerable<BTNode> nodes)
+    {
+        children = new List<BTNode>(nodes);
+    }
+
+    public override State Tick()
+    {
+        while (index < children.Count)
+        {
+            var state = children[index].Tick();
+            if (state == State.Running)
+                return State.Running;
+            if (state == State.Failure)
+            {
+                index = 0;
+                return State.Failure;
+            }
+            index++;
+        }
+        index = 0;
+        return State.Success;
+    }
+}
+
+public class Selector : BTNode
+{
+    private readonly List<BTNode> children;
+    private int index = 0;
+
+    public Selector(IEnumerable<BTNode> nodes)
+    {
+        children = new List<BTNode>(nodes);
+    }
+
+    public override State Tick()
+    {
+        while (index < children.Count)
+        {
+            var state = children[index].Tick();
+            if (state == State.Success)
+            {
+                index = 0;
+                return State.Success;
+            }
+            if (state == State.Running)
+                return State.Running;
+            index++;
+        }
+        index = 0;
+        return State.Failure;
+    }
+}
+
+public class ActionNode : BTNode
+{
+    private readonly Func<State> action;
+    public ActionNode(Func<State> act) { action = act; }
+    public override State Tick() => action();
+}

--- a/Assets/Scripts/BehaviorTree/BTNode.cs.meta
+++ b/Assets/Scripts/BehaviorTree/BTNode.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 826dd6ae132a48aaae2de06c9fad7a7e

--- a/Assets/Scripts/BehaviorTreeRunner.cs
+++ b/Assets/Scripts/BehaviorTreeRunner.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+
+public class BehaviorTreeRunner : MonoBehaviour
+{
+    public BTNode root;
+
+    void Update()
+    {
+        if (GameOverManager.Instance != null && GameOverManager.Instance.IsGameOver)
+            return;
+        root?.Tick();
+    }
+}

--- a/Assets/Scripts/BehaviorTreeRunner.cs.meta
+++ b/Assets/Scripts/BehaviorTreeRunner.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c027ffc36cac4e12ad74f08fba3f1281

--- a/Assets/Scripts/DifficultyManager.cs
+++ b/Assets/Scripts/DifficultyManager.cs
@@ -9,6 +9,7 @@ public class DifficultyManager : MonoBehaviour
     public GameObject shooterPrefab;
     public GameObject teleporterPrefab;
     public GameObject advancedPrefab;
+    public GameObject behaviorPrefab;
     [Tooltip("Prefab for the mini-boss.")]
     public GameObject bossPrefab;
     [Tooltip("Seconds until boss appears.")]
@@ -77,14 +78,16 @@ public class DifficultyManager : MonoBehaviour
     {
         GameObject prefab;
         float roll = Random.value;
-        if (roll < 0.25f)
+        if (roll < 0.2f)
             prefab = meleePrefab;
-        else if (roll < 0.5f)
+        else if (roll < 0.4f)
             prefab = shooterPrefab;
-        else if (roll < 0.75f)
+        else if (roll < 0.6f)
             prefab = teleporterPrefab;
-        else
+        else if (roll < 0.8f)
             prefab = advancedPrefab;
+        else
+            prefab = behaviorPrefab;
         if (prefab == null) return;
 
         Vector3 pos = GetEdgeSpawnPosition();
@@ -101,6 +104,8 @@ public class DifficultyManager : MonoBehaviour
             ai.moveSpeed *= slowRamp;
         else if (enemy.TryGetComponent<AdvancedEnemyAI>(out var adv))
             adv.moveSpeed *= slowRamp;
+        else if (enemy.TryGetComponent<BehaviorEnemyAI>(out var btree))
+            btree.moveSpeed *= slowRamp;
 
         // leave damage untouched
     }


### PR DESCRIPTION
## Summary
- add BehaviorTree runtime and node definitions
- add a simple BT-driven enemy with patrol, chase, attack and retreat
- create prefab for the new enemy and spawn it from DifficultyManager

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684da087c93083269e7ccf36ccb2c7f0