### PR TITLE
Add logistic difficulty curve

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -2876,6 +2876,8 @@ MonoBehaviour:
   chaseWeight: 0.5
   accuracyWeight: 1
   killTimeWeight: 1
+  growthRate: 0.5
+  midpoint: 10
 --- !u!4 &1488817118
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/DifficultyManager.cs
+++ b/Assets/Scripts/DifficultyManager.cs
@@ -34,6 +34,12 @@ public class DifficultyManager : MonoBehaviour
     [Tooltip("Multiplier added per second faster kill time.")]
     public float killTimeWeight = 1f;
 
+    [Header("Difficulty Curve")]
+    [Tooltip("Growth rate for the logistic difficulty curve.")]
+    public float growthRate = 0.5f;
+    [Tooltip("Midpoint for the logistic difficulty curve.")]
+    public float midpoint = 10f;
+
     private float nextSpawnTime;
     private bool bossSpawned = false;
     private int enemiesDefeated;
@@ -196,6 +202,8 @@ public class DifficultyManager : MonoBehaviour
                 killTimeFactor = killTimeWeight / m.AverageKillTime;
         }
 
-        return 1f + timeFactor + killFactor + damageFactor + chaseFactor + accuracyFactor + killTimeFactor;
+        float linearScore = timeFactor + killFactor + damageFactor + chaseFactor + accuracyFactor + killTimeFactor;
+        float logistic = 1f / (1f + Mathf.Exp(-growthRate * (linearScore - midpoint)));
+        return 1f + logistic;
     }
 }


### PR DESCRIPTION
## Summary
- add growth rate and midpoint fields for difficulty curve
- change difficulty calculation to logistic curve
- configure DifficultyManager object in SampleScene

## Testing
- `npm test` *(fails: no package.json)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684deca025888326ac868d27c4a666c4