### PR TITLE
Add NavMesh baking helper

### DIFF
--- a/Assets/Scripts/BSPDungeonGenerator.cs
+++ b/Assets/Scripts/BSPDungeonGenerator.cs
@@ -63,6 +63,8 @@ public class BSPDungeonGenerator : MonoBehaviour
 
         foreach (var pos in data.walls)
             Instantiate(wallPrefab, new Vector3(pos.x, pos.y, 1f), Quaternion.identity, transform);
+
+        GetComponent<NavMeshBaker>()?.Bake();
     }
 
     static IEnumerable<Vector2Int> Directions()

--- a/Assets/Scripts/DungeonGenerator.cs
+++ b/Assets/Scripts/DungeonGenerator.cs
@@ -58,6 +58,8 @@ public class DungeonGenerator : MonoBehaviour
 
         foreach (var pos in data.walls)
             Instantiate(wallPrefab, new Vector3(pos.x, pos.y, 1f), Quaternion.identity, transform);
+
+        GetComponent<NavMeshBaker>()?.Bake();
     }
 
     void ClearChildren()

--- a/Assets/Scripts/MarkovDungeonGenerator.cs
+++ b/Assets/Scripts/MarkovDungeonGenerator.cs
@@ -34,6 +34,7 @@ public class MarkovDungeonGenerator : MonoBehaviour
         ClearChildren();
         GenerateGrid();
         InstantiateTiles();
+        GetComponent<NavMeshBaker>()?.Bake();
     }
 
     void GenerateGrid()
@@ -75,8 +76,10 @@ public class MarkovDungeonGenerator : MonoBehaviour
                 GameObject prefab = grid[x, y] == 1 ? floorPrefab : wallPrefab;
                 if (prefab != null)
                     Instantiate(prefab, new Vector3(x, y, 1f), Quaternion.identity, transform);
-            }
         }
+        }
+
+        GetComponent<NavMeshBaker>()?.Bake();
     }
 
     void ClearChildren()

--- a/Assets/Scripts/NavMeshBaker.cs
+++ b/Assets/Scripts/NavMeshBaker.cs
@@ -1,0 +1,22 @@
+using UnityEngine;
+using UnityEngine.AI;
+
+[RequireComponent(typeof(NavMeshSurface))]
+public class NavMeshBaker : MonoBehaviour
+{
+    NavMeshSurface surface;
+
+    void Awake()
+    {
+        surface = GetComponent<NavMeshSurface>();
+    }
+
+    /// <summary>
+    /// Builds the NavMesh for the attached NavMeshSurface.
+    /// </summary>
+    public void Bake()
+    {
+        if (surface != null)
+            surface.BuildNavMesh();
+    }
+}

--- a/Assets/Scripts/NavMeshBaker.cs.meta
+++ b/Assets/Scripts/NavMeshBaker.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6c895ee3e38041df9049f0a00a137a95

--- a/Assets/Scripts/RoomGenerator.cs
+++ b/Assets/Scripts/RoomGenerator.cs
@@ -16,6 +16,7 @@ public class RoomGenerator : MonoBehaviour
     {
         ClearChildren();
         GenerateRoom();
+        GetComponent<NavMeshBaker>()?.Bake();
     }
 
     void GenerateRoom()
@@ -30,6 +31,7 @@ public class RoomGenerator : MonoBehaviour
                 transform
             );
         }
+        GetComponent<NavMeshBaker>()?.Bake();
     }
 
     public static HashSet<Vector2Int> GenerateRoomData(int width, int height)


### PR DESCRIPTION
## Summary
- add `NavMeshBaker` helper for building NavMeshes at runtime
- trigger baking in dungeon generator scripts after they build the level

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_684e7acce3008326815c6a4e7ce6b0d8