### PR TITLE
Fix sprite references

### DIFF
--- a/Assets/Prefabs/AdvancedEnemy.prefab
+++ b/Assets/Prefabs/AdvancedEnemy.prefab
@@ -81,7 +81,7 @@ SpriteRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
-  m_Sprite: {fileID: -2413806693520163455, guid: a86470a33a6bf42c4b3595704624658b, type: 3}
+  m_Sprite: {fileID: 21300000, guid: ec47f75fe8aff1644ac73998f4ad31b5, type: 3}
   m_Color: {r: 0.7433963, g: 0.16130286, b: 0.16130286, a: 1}
   m_FlipX: 0
   m_FlipY: 0

--- a/Assets/Prefabs/BehaviorEnemy.prefab
+++ b/Assets/Prefabs/BehaviorEnemy.prefab
@@ -82,7 +82,7 @@ SpriteRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
-  m_Sprite: {fileID: -2413806693520163455, guid: a86470a33a6bf42c4b3595704624658b, type: 3}
+  m_Sprite: {fileID: 21300000, guid: ec47f75fe8aff1644ac73998f4ad31b5, type: 3}
   m_Color: {r: 0.7433963, g: 0.16130286, b: 0.16130286, a: 1}
   m_FlipX: 0
   m_FlipY: 0

--- a/Assets/Prefabs/BossEnemy.prefab
+++ b/Assets/Prefabs/BossEnemy.prefab
@@ -81,7 +81,7 @@ SpriteRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
-  m_Sprite: {fileID: -2413806693520163455, guid: 4adeaf2d2b1c7417e89f026626d8264f, type: 3}
+  m_Sprite: {fileID: 21300000, guid: ec47f75fe8aff1644ac73998f4ad31b5, type: 3}
   m_Color: {r: 0.41960785, g: 0.27450982, b: 0.16130286, a: 1}
   m_FlipX: 0
   m_FlipY: 0

--- a/Assets/Prefabs/Enemy.prefab
+++ b/Assets/Prefabs/Enemy.prefab
@@ -81,7 +81,7 @@ SpriteRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
-  m_Sprite: {fileID: -2413806693520163455, guid: a86470a33a6bf42c4b3595704624658b, type: 3}
+  m_Sprite: {fileID: 21300000, guid: ec47f75fe8aff1644ac73998f4ad31b5, type: 3}
   m_Color: {r: 0.7433963, g: 0.16130286, b: 0.16130286, a: 1}
   m_FlipX: 0
   m_FlipY: 0

--- a/Assets/Prefabs/FloorTile.prefab
+++ b/Assets/Prefabs/FloorTile.prefab
@@ -76,8 +76,7 @@ SpriteRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
-  m_Sprite: {fileID: 7482667652216324306, guid: 311925a002f4447b3a28927169b83ea6,
-    type: 3}
+  m_Sprite: {fileID: 21300000, guid: a07735877a3bd644094331b137b71878, type: 3}
   m_Color: {r: 0.10204063, g: 0.5754717, b: 0.07329121, a: 1}
   m_FlipX: 0
   m_FlipY: 0

--- a/Assets/Prefabs/Health_Pickup.prefab
+++ b/Assets/Prefabs/Health_Pickup.prefab
@@ -78,7 +78,7 @@ SpriteRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
-  m_Sprite: {fileID: -2413806693520163455, guid: a86470a33a6bf42c4b3595704624658b, type: 3}
+  m_Sprite: {fileID: 21300000, guid: ec47f75fe8aff1644ac73998f4ad31b5, type: 3}
   m_Color: {r: 0.8392157, g: 0.85882354, b: 0.22745098, a: 1}
   m_FlipX: 0
   m_FlipY: 0

--- a/Assets/Prefabs/ShooterEnemy.prefab
+++ b/Assets/Prefabs/ShooterEnemy.prefab
@@ -80,7 +80,7 @@ SpriteRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
-  m_Sprite: {fileID: -2413806693520163455, guid: a86470a33a6bf42c4b3595704624658b, type: 3}
+  m_Sprite: {fileID: 21300000, guid: ec47f75fe8aff1644ac73998f4ad31b5, type: 3}
   m_Color: {r: 0.7433963, g: 0.16130286, b: 0.16130286, a: 1}
   m_FlipX: 0
   m_FlipY: 0

--- a/Assets/Prefabs/TeleportingEnemy.prefab
+++ b/Assets/Prefabs/TeleportingEnemy.prefab
@@ -80,7 +80,7 @@ SpriteRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
-  m_Sprite: {fileID: -2413806693520163455, guid: a86470a33a6bf42c4b3595704624658b, type: 3}
+  m_Sprite: {fileID: 21300000, guid: ec47f75fe8aff1644ac73998f4ad31b5, type: 3}
   m_Color: {r: 0.7433963, g: 0.16130286, b: 0.16130286, a: 1}
   m_FlipX: 0
   m_FlipY: 0

--- a/Assets/Prefabs/UtilityEnemy.prefab
+++ b/Assets/Prefabs/UtilityEnemy.prefab
@@ -81,7 +81,7 @@ SpriteRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
-  m_Sprite: {fileID: -2413806693520163455, guid: a86470a33a6bf42c4b3595704624658b, type: 3}
+  m_Sprite: {fileID: 21300000, guid: ec47f75fe8aff1644ac73998f4ad31b5, type: 3}
   m_Color: {r: 0.7433963, g: 0.16130286, b: 0.16130286, a: 1}
   m_FlipX: 0
   m_FlipY: 0

--- a/Assets/Prefabs/WallTile.prefab
+++ b/Assets/Prefabs/WallTile.prefab
@@ -77,7 +77,7 @@ SpriteRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
-  m_Sprite: {fileID: 7482667652216324306, guid: 311925a002f4447b3a28927169b83ea6, type: 3}
+  m_Sprite: {fileID: 21300000, guid: a07735877a3bd644094331b137b71878, type: 3}
   m_Color: {r: 0.5943396, g: 0.5943396, b: 0.5943396, a: 1}
   m_FlipX: 0
   m_FlipY: 0

--- a/Assets/Prefabs/XP_Pickup.prefab
+++ b/Assets/Prefabs/XP_Pickup.prefab
@@ -78,7 +78,7 @@ SpriteRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
-  m_Sprite: {fileID: -2413806693520163455, guid: a86470a33a6bf42c4b3595704624658b, type: 3}
+  m_Sprite: {fileID: 21300000, guid: ec47f75fe8aff1644ac73998f4ad31b5, type: 3}
   m_Color: {r: 0.8392157, g: 0.85882354, b: 0.22745098, a: 1}
   m_FlipX: 0
   m_FlipY: 0

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -468,8 +468,7 @@ SpriteRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
-  m_Sprite: {fileID: -2413806693520163455, guid: a86470a33a6bf42c4b3595704624658b,
-    type: 3}
+  m_Sprite: {fileID: 21300000, guid: ec47f75fe8aff1644ac73998f4ad31b5, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0


### PR DESCRIPTION
## Summary
- point missing enemy and pickup sprites to a valid sprite sheet
- switch floor/wall tiles to use a present stone texture
- update player sprite reference in SampleScene

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684e936d7ab083268643c98dd4f7bff3