### PR TITLE
Remove NavMesh usage

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -95,30 +95,6 @@ LightmapSettings:
     m_LightProbeSampleCountMultiplier: 4
   m_LightingDataAsset: {fileID: 0}
   m_LightingSettings: {fileID: 0}
---- !u!196 &4
-NavMeshSettings:
-  serializedVersion: 2
-  m_ObjectHideFlags: 0
-  m_BuildSettings:
-    serializedVersion: 3
-    agentTypeID: 0
-    agentRadius: 0.5
-    agentHeight: 2
-    agentSlope: 45
-    agentClimb: 0.4
-    ledgeDropHeight: 0
-    maxJumpAcrossDistance: 0
-    minRegionArea: 2
-    manualCellSize: 0
-    cellSize: 0.16666667
-    manualTileSize: 0
-    tileSize: 256
-    buildHeightMesh: 0
-    maxJobWorkers: 0
-    preserveTilesOutsideBounds: 0
-    debug:
-      m_Flags: 0
-  m_NavMeshData: {fileID: 0}
 --- !u!1 &45954906
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/NavMeshStripper.cs
+++ b/Assets/Scripts/NavMeshStripper.cs
@@ -1,0 +1,29 @@
+using UnityEngine;
+using UnityEngine.AI;
+using UnityEngine.SceneManagement;
+
+/// <summary>
+/// Removes any NavMesh-related components from loaded scenes at runtime.
+/// This ensures the game does not rely on Unity's NavMesh system.
+/// </summary>
+public static class NavMeshStripper
+{
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+    static void Init()
+    {
+        SceneManager.sceneLoaded += (scene, mode) => RemoveNavMeshComponents();
+        RemoveNavMeshComponents();
+    }
+
+    static void RemoveNavMeshComponents()
+    {
+        foreach (var agent in Object.FindObjectsOfType<NavMeshAgent>())
+        {
+            Object.Destroy(agent);
+        }
+        foreach (var obstacle in Object.FindObjectsOfType<NavMeshObstacle>())
+        {
+            Object.Destroy(obstacle);
+        }
+    }
+}

--- a/Assets/Scripts/NavMeshStripper.cs.meta
+++ b/Assets/Scripts/NavMeshStripper.cs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6e960b56a0537a848bf87c519ed9a9cb
+timeCreated: 1712780000
+licenseType: Free
+DefaultImporter:
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- remove NavMeshSettings from SampleScene
- add NavMeshStripper utility to ensure all NavMesh components are removed at runtime

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e96bfdccc8326831cd40d03f011b8